### PR TITLE
Improve coffee gulp workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 * reactjs
 * reflux
 * react-router
+* bootstrap (Twitter Bootstrap's official Sass version)
+* preprocessify (for environments management)
 
 ## Usage
 

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -15,7 +15,8 @@
     "test",
     "tests"
   ],
-  "dependencies": {<% if (includeModernizr) { %>
+  "dependencies": {
+    "bootstrap-sass": ">=3.3.4",<% if (includeModernizr) { %>
     "modernizr": "~2.8.3"<% } %>
   }
 }

--- a/app/templates/_package-gulp.json
+++ b/app/templates/_package-gulp.json
@@ -6,42 +6,54 @@
   "license": "<%= license %>",
   "dependencies": {
     "jquery": "~2.1.3",
-    "react": "~0.12.2",
-    "react-router": "~0.12.0",
-    "reflux": "~0.2.5"
+    "lodash": "^3.5.0",
+    "react": "~0.13.1",
+    "react-bootstrap": "^0.17.0",
+    "react-router": "~0.13.1",
+    "reflux": "~0.2.7",
+    "seamless-immutable": "^2.0.1",
+    "transducers-js": "^0.4.143"
   },
   "devDependencies": {
     "browserify": "~8.1.3",<% if (includeCoffee) { %><% if (includeJest) { %>
-    "coffee-react": "~2.4.1",<% } %>
-    "coffee-reactify": "~2.4.1",
+    "coffee-react": "~3.0.1",<% } %>
+    "coffee-reactify": "~3.0.0",
     "coffee-script": "~1.9.0",<% } %>
     "del": "~1.1.1",
+    "domain": "0.0.1",
     "gulp": "~3.8.11",
     "gulp-autoprefixer": "~2.1.0",<% if (includeSass) { %>
+    "gulp-cached": "^1.0.2",
     "gulp-compass": "^2.0.3",<% } %>
     "gulp-filter": "~2.0.1",
     "gulp-htmlmin": "~1.0.0",
+    "gulp-if": "^1.2.5",
     "gulp-imagemin": "~2.1.0",
     "gulp-load-plugins": "~0.8.0",
     "gulp-minify-css": "~0.4.5",
-    "gulp-plumber": "~0.6.6",<% if (includeCoffee) { %>
+    "gulp-plumber": "~0.6.6",
+    "gulp-preprocess": "^1.2.0",<% if (includeCoffee) { %>
     "gulp-rename": "~1.2.0",<% } %>
     "gulp-rev-all": "~0.7.6",
     "gulp-rev-replace": "~0.3.3",
     "gulp-size": "~1.2.0",
+    "gulp-tap": "^0.1.3",
     "gulp-uglify": "~1.1.0",
     "gulp-useref": "~1.1.1",
+    "gulp-util": "^3.0.4",
     "gulp-webserver": "~0.9.0",<% if (includeJest) { %>
-    "jest-cli": "~0.2.2",<% } %><% if (!includeCoffee) { %>
+    "jest-cli": "~0.2.2",<% } %>
+    "preprocessify": "~0.0.3",<% if (!includeCoffee) { %>
     "reactify": "~1.0.0",<% if (includeJest) { %>
     "react-tools": "^0.12.2",<% } } %>
     "run-sequence": "~1.0.2",
-    "vinyl-source-stream": "~1.0.0"
+    "vinyl-source-stream": "~1.1.0"
   },
   "engines": {
     "node": ">=0.10.0"
   },
   "scripts": {
+    "postinstall": "bower install",
     "start": "./node_modules/gulp/bin/gulp.js serve",<% if (includeJest) { %>
     "test": "./node_modules/jest-cli/bin/jest.js",<% } %>
     "build": "./node_modules/gulp/bin/gulp.js build"

--- a/app/templates/app/styles/main.scss
+++ b/app/templates/app/styles/main.scss
@@ -1,3 +1,7 @@
+$icon-font-path: "../vendor/bootstrap-sass/assets/fonts/bootstrap/";
+@import "../vendor/bootstrap-sass/assets/stylesheets/bootstrap-sprockets";
+@import "../vendor/bootstrap-sass/assets/stylesheets/bootstrap";
+
 body {
     background: #fafafa;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/app/templates/preprocessor.js.coffee
+++ b/app/templates/preprocessor.js.coffee
@@ -1,3 +1,4 @@
+'use strict';
 var CoffeeReact = require('coffee-react');
 var CoffeeScript = require('coffee-script');
 


### PR DESCRIPTION
This pull request contains gulp improvement and new functionality. Please merge what you think useful. The gulp improvement for coffee version can be done also for js version. Hope you will enjoy my contribution!

Improve coffee gulp workflow: 
- Avoid stop watching on browserify errors
- Detail log on browserify errors
- Cache sass files to compile only modified files

Add twitter bootstrap support

Add multi conf support with preprocessify

Add useful js libraries (lodash, seamless-immutable and transducers)

Trigger bower install after each npm install