### PR TITLE
Extraneous comma in package-gulp.json

### DIFF
--- a/app/templates/_package-gulp.json
+++ b/app/templates/_package-gulp.json
@@ -8,7 +8,7 @@
     "jquery": "~2.1.3",
     "react": "~0.13.1",
     "react-router": "~0.13.1",
-    "reflux": "~0.2.7",
+    "reflux": "~0.2.7"
   },
   "devDependencies": {
     "browserify": "~8.1.3",<% if (includeCoffee) { %><% if (includeJest) { %>


### PR DESCRIPTION
Patch f0b3ec2288c5d26a23c11fa83c84da9faf6345a0 cleaned up the dependancies in package-gulp.json, but left a dangling comma at the end.

The extraneous comma breaks `npm install`.

This patch removes the dangling comma, so `npm install` works again.