### PR TITLE
Include "actions" generator in the distributed package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-react-reflux",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A Yeoman Generator for facebook's React framework and flux architecture using reflux.",
   "license": "MIT",
   "main": "app/index.js",
@@ -23,7 +23,8 @@
   "files": [
     "app",
     "component",
-    "store"
+    "store",
+    "actions"
   ],
   "keywords": [
     "yeoman-generator",


### PR DESCRIPTION
Right now only "app", "component" and "store" are installed, and `yo react-reflux:actions foo` runs the main generator.